### PR TITLE
fix(admin): switch stress word import to keyset pagination

### DIFF
--- a/main/management/commands/import_stress_words_from_supabase.py
+++ b/main/management/commands/import_stress_words_from_supabase.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
 
         client = _client()
-        start = 0
+        last_id = 0
         fetched = 0
         total_created_or_updated = 0
         supports_target = connections[
@@ -35,15 +35,16 @@ class Command(BaseCommand):
             if limit is not None and fetched >= limit:
                 break
 
-            end = start + page_size - 1
+            page_limit = page_size
             if limit is not None:
-                end = min(end, start + (limit - fetched) - 1)
+                page_limit = min(page_limit, limit - fetched)
 
             response = (
                 client.table(TABLE)
                 .select(COLUMNS)
                 .order("id")
-                .range(start, end)
+                .gt("id", last_id)
+                .limit(page_limit)
                 .execute()
             )
             rows = response.data
@@ -73,7 +74,7 @@ class Command(BaseCommand):
                 )
                 total_created_or_updated += len(chunk)
 
-            start += page_size
+            last_id = rows[-1]["id"]
 
         if dry_run:
             self.stdout.write(self.style.SUCCESS(f"Dry run: would import {fetched} rows."))

--- a/main/tests/test_import_stress_words_from_supabase.py
+++ b/main/tests/test_import_stress_words_from_supabase.py
@@ -19,19 +19,20 @@ def load_fixture():
 
 
 def make_mock_client(rows):
-    """Build a mock Supabase client that paginates over `rows` via .range(start, end)."""
+    """Build a mock Supabase client that paginates over `rows` via .gt("id", last_id).limit(n)."""
     client = MagicMock()
 
     def execute_side_effect():
         query = client.table.return_value.select.return_value.order.return_value
-        start, end = query.range.call_args[0]
-        page = rows[start:end + 1]
+        _, last_id = query.gt.call_args[0]
+        (page_limit,) = query.gt.return_value.limit.call_args[0]
+        page = [row for row in rows if row["id"] > last_id][:page_limit]
         response = MagicMock()
         response.data = page
         return response
 
     query_mock = client.table.return_value.select.return_value.order.return_value
-    query_mock.range.return_value.execute.side_effect = execute_side_effect
+    query_mock.gt.return_value.limit.return_value.execute.side_effect = execute_side_effect
     return client
 
 


### PR DESCRIPTION
OFFSET-based .range() paging hit statement timeouts on Supabase past ~115k rows since Postgres has to scan and discard all prior rows on each page. Cursor on id (.gt + .limit) keeps each page O(page_size) regardless of depth.


Claude-Session: https://claude.ai/code/session_01MoBLTnMW2WjMChiixYSJw1